### PR TITLE
Fix authorship wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Negotiating-Platform-for-Youth-Diplomacy
-This is our first large project. It is developed by Kevin Shelton && Liu Fanshuo. During the developing process, we greatly depended on AI tools like ChatGPT and Cursor, because we have no practical experience in developing. 
+This is our first large project. It is developed by Kevin Shelton and Liu Fanshuo. During the developing process, we greatly depended on AI tools like ChatGPT and Cursor, because we have no practical experience in developing. 
 I am responsible for the backend and the integration of the project while my partner Liu is responsible for the frontend of the project.
 It's not easy-peasy for college students like us to develop such a significant project. But it's definitely worthwhile!
 We do enjoy our time!


### PR DESCRIPTION
## Summary
- replace `Kevin Shelton && Liu Fanshuo` with `Kevin Shelton and Liu Fanshuo` in README

## Testing
- `node node_modules/jest/bin/jest.js` *(fails: TextChatController, textChat.integration, scoring.integration)*

------
https://chatgpt.com/codex/tasks/task_e_6840450bbd448327b4a27feb646598e5