### PR TITLE
Ensure scheduleEvent returns event object

### DIFF
--- a/services/timeService.js
+++ b/services/timeService.js
@@ -5,7 +5,7 @@ module.exports.timeEvents = timeEvents;
 
 function scheduleEvent(name, timeInfo, callback) {
   timeEvents[name] = { timeInfo, callback, paused: false };
-  return true;
+  return timeEvents[name];
 }
 
 function pauseEvent(name) {

--- a/tests/services/timeService.test.js
+++ b/tests/services/timeService.test.js
@@ -10,8 +10,9 @@ describe("TimeService", () => {
 
   it("scheduleEvent", () => {
     const cb = () => {};
-    expect(scheduleEvent("e1", { t:1 }, cb)).toBe(true);
-    expect(timeEvents.e1).toEqual({ timeInfo:{ t:1 }, callback:cb, paused:false });
+    const ev = scheduleEvent("e1", { t:1 }, cb);
+    expect(ev).toEqual({ timeInfo:{ t:1 }, callback:cb, paused:false });
+    expect(ev).toBe(timeEvents.e1);
   });
 
   it("pauseEvent / resumeEvent", () => {


### PR DESCRIPTION
## Summary
- return the stored event object from `scheduleEvent`
- update tests to assert the returned object matches stored data

## Testing
- `node node_modules/jest/bin/jest.js` *(fails: TextChatController and integration tests due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684045119ec4832786e7caf6d3595455