### PR TITLE
Fix timer updates and admin deletion rights

### DIFF
--- a/controllers/roomController.js
+++ b/controllers/roomController.js
@@ -1,5 +1,4 @@
 "use strict";
-const roomService = require('../services/roomService');
 const store = require('../data/store');
 const { generateToken } = require('../middleware/auth');
 
@@ -7,7 +6,7 @@ const { generateToken } = require('../middleware/auth');
 async function getRooms(req, res) {
   try {
     const userId = req.user.userId;
-    const rooms = roomService.getRoomsByUser(userId);
+    const rooms = store.getRoomsByUser(userId);
     res.json(rooms);
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -147,7 +146,11 @@ async function deleteRoom(req, res) {
     
     // 检查权限
     const user = store.findUserById(req.user.userId);
-    if (!room.participants.some(p => p.user === user.userId && p.role === 'admin')) {
+    const isCreator = room.createdBy === user.userId;
+    const isRoomAdmin = room.participants.some(p => p.user === user.userId && p.role === 'admin');
+
+    // 允许房间创建者、房间管理员或具有全局 admin 角色的用户删除房间
+    if (!(isCreator || isRoomAdmin || user.role === 'admin')) {
       return res.status(403).json({ error: '没有权限删除房间' });
     }
     

--- a/data/store.js
+++ b/data/store.js
@@ -95,6 +95,11 @@ store.findRoomByInviteCode = (inviteCode) => {
   return store.rooms.find(r => r.inviteCode === inviteCode);
 };
 
+// 根据用户ID获取其参与的所有房间
+store.getRoomsByUser = (userId) => {
+  return store.rooms.filter(r => r.participants.some(p => p.userId === userId));
+};
+
 store.addRoom = (room) => {
   // 生成邀请码
   const inviteCode = Math.random().toString(36).substring(2, 8).toUpperCase();

--- a/public/index.html
+++ b/public/index.html
@@ -84,5 +84,13 @@
       }
     });
   </script>
+  <script src="/js/auth.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.auth && window.auth.checkAuth()) {
+        document.querySelectorAll('a[href="/login"], a[href="/register"]').forEach(el => el.style.display = 'none');
+      }
+    });
+  </script>
 </body>
-</html> 
+</html>

--- a/public/room.html
+++ b/public/room.html
@@ -1402,6 +1402,12 @@
           timerDisplay.style.color = '';
         }
       }
+
+      // 供 WebSocket 消息调用，更新计时器显示
+      window.updateTimerDisplay = function(sec) {
+        currentTime = sec;
+        updateDisplay();
+      };
     }
 
     // 初始化日程项

--- a/services/timeService.js
+++ b/services/timeService.js
@@ -4,8 +4,30 @@ const timeEvents = {};
 module.exports.timeEvents = timeEvents;
 
 function scheduleEvent(name, timeInfo, callback) {
-  timeEvents[name] = { timeInfo, callback, paused: false };
-  return timeEvents[name];
+  // 初始化剩余秒数，便于倒计时逻辑
+  const info = {
+    ...timeInfo,
+    remainingSec: typeof timeInfo.durationSec === 'number' ? timeInfo.durationSec : 0
+  };
+  const event = {
+    timeInfo: info,
+    callback,
+    paused: false,
+    interval: null
+  };
+  event.interval = setInterval(() => {
+    if (!event.paused && event.timeInfo.remainingSec > 0) {
+      event.timeInfo.remainingSec -= 1;
+      if (event.timeInfo.remainingSec <= 0) {
+        clearInterval(event.interval);
+        if (typeof event.callback === 'function') {
+          event.callback();
+        }
+      }
+    }
+  }, 1000);
+  timeEvents[name] = event;
+  return event;
 }
 
 function pauseEvent(name) {

--- a/tests/services/timeService.test.js
+++ b/tests/services/timeService.test.js
@@ -5,14 +5,18 @@ const { timeData } = require("../../data/timeData");
 
 describe("TimeService", () => {
   beforeEach(() => {
+    Object.values(timeEvents).forEach(ev => ev.interval && clearInterval(ev.interval));
     Object.keys(timeEvents).forEach(k => delete timeEvents[k]);
   });
 
   it("scheduleEvent", () => {
     const cb = () => {};
-    const ev = scheduleEvent("e1", { t:1 }, cb);
-    expect(ev).toEqual({ timeInfo:{ t:1 }, callback:cb, paused:false });
+    const ev = scheduleEvent("e1", { durationSec:1, label:"t" }, cb);
+    expect(ev.callback).toBe(cb);
+    expect(ev.paused).toBe(false);
+    expect(ev.timeInfo.remainingSec).toBe(1);
     expect(ev).toBe(timeEvents.e1);
+    clearInterval(ev.interval);
   });
 
   it("pauseEvent / resumeEvent", () => {


### PR DESCRIPTION
## Summary
- hide login/register on home after auth check
- allow global admin to remove any room
- expose `updateTimerDisplay` for websocket updates

## Testing
- `npm test` *(fails: jest permission issues and integration test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68404ab0e4dc8327bf5f65668d6380f4