### PR TITLE
Fix login token and add chat message controls

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -48,6 +48,7 @@ async function register(req, res) {
 
     res.status(201).json({
       message: '注册成功',
+      token,
       user: {
         userId: user.userId,
         username: user.username,
@@ -88,6 +89,7 @@ async function login(req, res) {
 
     res.json({
       message: '登录成功',
+      token,
       user: {
         userId: user.userId,
         username: user.username,

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -59,6 +59,9 @@ const verifyToken = async (req, res, next) => {
   }
 };
 
+// 兼容旧代码的别名
+const requireAuth = verifyToken;
+
 // 检查用户角色
 const requireRoles = (roles) => {
   return (req, res, next) => {
@@ -114,7 +117,8 @@ const requireRoomParticipant = async (req, res, next) => {
 module.exports = {
   generateToken,
   verifyToken,
+  requireAuth,
   requireRoles,
   requireRoomAdmin,
   requireRoomParticipant
-}; 
+};

--- a/public/chat/chat-room.html
+++ b/public/chat/chat-room.html
@@ -90,8 +90,25 @@
         .status-speaking { background: #2196f3; }
         .status-raising-hand { background: #ff9800; }
         .status-muted { background: #f44336; }
-        .emoji-picker { position: absolute; bottom: 100%; right: 0; background: white; border: 1px solid #ddd; border-radius: 8px; padding: 10px; display: none; }
-        .emoji-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 5px; }
+        .emoji-picker {
+            position: absolute;
+            bottom: 100%;
+            right: 0;
+            background: white;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 8px;
+            display: none;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+            width: 240px;
+        }
+        .emoji-grid {
+            display: grid;
+            grid-template-columns: repeat(8, 1fr);
+            gap: 6px;
+            max-height: 200px;
+            overflow-y: auto;
+        }
         .emoji-item { cursor: pointer; padding: 5px; text-align: center; border-radius: 4px; }
         .emoji-item:hover { background: #f0f0f0; }
         .system-message { text-align: center; color: #666; font-style: italic; margin: 10px 0; }
@@ -494,6 +511,7 @@
                             <span class="message-role role-${message.role}">${getRoleName(message.role)}</span>
                             <span class="message-country">${message.country}</span>
                             <button class="quote-btn" data-msgid="${message.id}" data-from="${message.userId || ''}" style="margin-left:8px;font-size:12px;color:#0084ff;background:none;border:none;cursor:pointer;">引用</button>
+                            ${isOwnMessage ? `<button class="edit-btn" data-msgid="${message.id}" style="margin-left:6px;font-size:12px;color:#28a745;background:none;border:none;cursor:pointer;">编辑</button><button class="revoke-btn" data-msgid="${message.id}" style="margin-left:6px;font-size:12px;color:#dc3545;background:none;border:none;cursor:pointer;">撤回</button>` : ''}
                         </div>
                         ${quoteHtml}
                         <div class="message-bubble${message.revoked ? ' revoked' : ''}${isOwnMessage ? ' own' : ''}">
@@ -898,10 +916,25 @@ emojiPanel.addEventListener('click', function(e) {
                     showQuoteBar();
                 }
             }
-            // 关闭引用条
             if (e.target.id === 'cancelQuoteBtn') {
                 currentQuote = null;
                 hideQuoteBar();
+            }
+            if (e.target.classList.contains('revoke-btn')) {
+                const id = e.target.getAttribute('data-msgid');
+                if (confirm('确定撤回此消息?')) {
+                    sendRevoke(id);
+                }
+            }
+            if (e.target.classList.contains('edit-btn')) {
+                const id = e.target.getAttribute('data-msgid');
+                const msg = messages.find(m => m.id === id);
+                if (msg) {
+                    const newText = prompt('修改消息内容', typeof msg.content === 'string' ? msg.content : '');
+                    if (newText !== null) {
+                        sendEdit(id, newText);
+                    }
+                }
             }
         });
         // 显示引用条
@@ -942,6 +975,42 @@ emojiPanel.addEventListener('click', function(e) {
 
         function closeImageModal() {
             document.getElementById('imageModal').style.display = "none";
+        }
+
+        // 发送撤回消息
+        function sendRevoke(id) {
+            if (ws) {
+                ws.send(JSON.stringify({ type: 'revokeMessage', messageId: id }));
+            }
+        }
+
+        // 编辑消息
+        async function sendEdit(id, newText) {
+            try {
+                const res = await fetch('/api/messages/' + id, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + localStorage.getItem('token')
+                    },
+                    body: JSON.stringify({ content: newText })
+                });
+                await handleApiResponse(res);
+                if (res.ok) {
+                    const msg = messages.find(m => m.id === id);
+                    if (msg) {
+                        msg.content = newText;
+                        msg.edited = true;
+                    }
+                    const bubble = document.querySelector('#msg-' + id + ' .message-bubble');
+                    if (bubble) bubble.textContent = newText + ' (已编辑)';
+                } else {
+                    const err = await res.json();
+                    alert(err.error || '编辑失败');
+                }
+            } catch (err) {
+                alert('编辑失败: ' + err.message);
+            }
         }
 
         // 滚动到指定消息


### PR DESCRIPTION
## Summary
- return token in login/register responses
- export `requireAuth` alias in auth middleware
- improve emoji picker style and add edit/revoke buttons in chat UI
- support editing and revoking messages via frontend

## Testing
- `npm test` *(fails: jest permission and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fb3b4b1c883278126dd8c3aa228b3