### PR TITLE
Fix chat UI with image preview

### DIFF
--- a/public/chat/chat-room.css
+++ b/public/chat/chat-room.css
@@ -33,7 +33,7 @@ body {
   color: #555;
 }
 #chatMessages:not(.simple-mode) .message-bubble {
-  max-width: 75%;
+  max-width: 33vw;
   padding: 0.6rem 1rem;
   border-radius: 1rem;
   word-wrap: break-word;
@@ -214,7 +214,8 @@ body {
 
 /* === patched 2025‑06‑27c === */
 .emoji-picker {
-  width: 260px !important;
+  width: fit-content !important;
+  max-width: 220px !important;
   max-height: 200px !important;
   overflow-y: auto !important;
   overflow-x: hidden !important;
@@ -222,14 +223,21 @@ body {
 }
 .emoji-grid {
   display: grid !important;
-  grid-template-columns: repeat(8, 1fr) !important;
+  grid-template-columns: repeat(8, 28px) !important;
   gap: 4px !important;
   padding: 8px !important;
+}
+.emoji-item {
+  width: 28px !important;
+  height: 28px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 .message-bubble {
   display: inline-block !important;
   width: auto !important;
-  max-width: 280px !important;
+  max-width: 33vw !important;
   min-width: 0 !important;
   padding: 6px 10px !important;
   white-space: pre-wrap !important;
@@ -252,7 +260,7 @@ body {
 }
 .message-bubble {
   width: fit-content;
-  max-width: 380px;
+  max-width: 33vw;
   min-width: 0;
 }
 
@@ -295,7 +303,7 @@ body {
 }
 .message-bubble {
   width: fit-content;
-  max-width: 380px;
+  max-width: 33vw;
   min-width: 0;
   word-break: break-word;
   white-space: pre-wrap;
@@ -313,4 +321,9 @@ body {
   color: #fff;
   border-top-right-radius: 4px;
   border-top-left-radius: 18px;
+}
+
+.re-edit {
+  color: #0084ff;
+  cursor: pointer;
 }

--- a/public/chat/chat-room.html
+++ b/public/chat/chat-room.html
@@ -22,20 +22,22 @@
         .chat-header { background: white; padding: 20px; border-bottom: 1px solid #e1e5e9; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
         .chat-messages { flex: 1; overflow-y: auto; padding: 12px; background: #f8f9fa; }
         .message-item { display: flex; align-items: flex-start; margin-bottom: 10px; }
-        .message-item.own { flex-direction: row-reverse; }
+        .message-item.own { flex-direction: row-reverse; justify-content: flex-end; }
         .message-item.own .message-content { margin-left: 0; margin-right: 12px; align-items: flex-end; }
         .message-item.own .message-bubble { background-color: #0084ff; color: white; }
         .message-item.own .message-bubble.own { background-color: #0084ff; color: white; }
         .message-avatar { width: 40px; height: 40px; border-radius: 50%; margin-right: 12px; flex-shrink: 0; }
-        .message-content { 
-            display: flex; 
-            flex-direction: column; 
-            max-width: 70%; 
-            margin-left: 12px; 
+        .message-content {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            width: fit-content;
+            max-width: 33vw;
+            margin-left: 12px;
         }
         .message-header { display: flex; align-items: center; margin-bottom: 2px; }
         .message-name { font-weight: bold; color: #1a1a1a; margin-right: 8px; }
-        .message-role { font-size: 12px; padding: 2px 6px; border-radius: 10px; color: white; }
+        .message-role { font-size: 12px; padding: 2px 6px; border-radius: 10px; color: #333; background:#f0f0f0; }
         .message-country { font-size: 12px; color: #666; margin-left: 8px; }
         .message-time { font-size: 12px; color: #999; margin-left: auto; }
         .message-bubble {
@@ -57,7 +59,7 @@
         }
         .message-bubble.revoked { background: #f1f3f4; color: #666; font-style: italic; }
         .chat-input { background: white; padding: 20px; border-top: 1px solid #e1e5e9; }
-        .input-container { display: flex; gap: 10px; }
+        .input-container { display: flex; gap: 10px; align-items: flex-end; }
         .message-input { 
             flex: 1; 
             padding: 8px 12px; 
@@ -100,7 +102,7 @@
             padding: 8px;
             display: none;
             box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-            width: 280px;
+            width: auto;
 
         }
         .emoji-grid {
@@ -110,7 +112,7 @@
             max-height: 200px;
             overflow-y: auto;
         }
-        .emoji-item { cursor: pointer; padding: 5px; text-align: center; border-radius: 4px; }
+        .emoji-item { cursor: pointer; padding: 5px; text-align: center; border-radius: 4px; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; }
         .emoji-item:hover { background: #f0f0f0; }
         .system-message { text-align: center; color: #666; font-style: italic; margin: 10px 0; }
         .raise-hand-btn { padding: 8px 16px; background: #ff9800; color: white; border: none; border-radius: 16px; cursor: pointer; margin-right: 10px; }
@@ -143,17 +145,6 @@
         .image-icon {
             color: white;
             font-size: 24px;
-        }
-        .image-caption {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.5);
-            color: white;
-            padding: 5px;
-            border-radius: 0 0 8px 8px;
-            text-align: center;
         }
         .message-image {
             max-width: 160px;
@@ -224,6 +215,8 @@
                 </div>
                 <!-- 表情面板 -->
                 <div id="emojiPanel" class="emoji-picker" style="display:none;position:absolute;z-index:1001;"></div>
+                <!-- 图片预览面板 -->
+                <div id="imagePreviewPanel" style="display:none;position:absolute;z-index:1002;background:#fff;border:1px solid #ddd;padding:8px;"></div>
                 <!-- 引用条 -->
                 <div id="quoteBar" style="display:none;background:#f5f5f5;border-left:3px solid #0084ff;padding:6px 12px;margin-bottom:4px;color:#555;font-size:13px;">
                     <div style="display:flex;align-items:center;">
@@ -256,6 +249,7 @@
         let currentUser = null;
         let users = [];
         let messages = [];
+        let revokedCache = {};
         let isRaisingHand = false;
         let currentQuote = null;
 
@@ -398,8 +392,21 @@
                         case 'system':
                             addSystemMessage(message.message);
                             break;
+                        case 'revokeMessage':
+                            // 自己撤回后收到，保存内容供重新编辑
+                            revokedCache[message.messageId] = message.content;
+                            handleMessageRevoked(
+                                message.messageId,
+                                currentUser ? currentUser.username : '',
+                                true
+                            );
+                            break;
                         case 'messageRevoked':
-                            handleMessageRevoked(message.messageId);
+                            if (currentUser && message.revokedBy === currentUser.username) {
+                                // 自己撤回的消息已处理
+                                break;
+                            }
+                            handleMessageRevoked(message.messageId, message.revokedBy, false);
                             break;
                         case 'raiseHand':
                             handleRaiseHand(message);
@@ -512,7 +519,7 @@
                             <span class="message-role role-${message.role}">${getRoleName(message.role)}</span>
                             <span class="message-country">${message.country}</span>
                             <button class="quote-btn" data-msgid="${message.id}" data-from="${message.userId || ''}" style="margin-left:8px;font-size:12px;color:#0084ff;background:none;border:none;cursor:pointer;">引用</button>
-                            ${isOwnMessage ? `<button class="edit-btn" data-msgid="${message.id}" style="margin-left:6px;font-size:12px;color:#28a745;background:none;border:none;cursor:pointer;">编辑</button><button class="revoke-btn" data-msgid="${message.id}" style="margin-left:6px;font-size:12px;color:#dc3545;background:none;border:none;cursor:pointer;">撤回</button>` : ''}
+                            ${isOwnMessage ? `<button class="revoke-btn" data-msgid="${message.id}" style="margin-left:6px;font-size:12px;color:#dc3545;background:none;border:none;cursor:pointer;">撤回</button>` : ''}
                         </div>
                         ${quoteHtml}
                         <div class="message-bubble${message.revoked ? ' revoked' : ''}${isOwnMessage ? ' own' : ''}">
@@ -541,7 +548,6 @@
                              onclick='openImageModal(this.src, "${message.content.alt || '图片'}")'
                              onerror='this.parentElement.innerHTML="<div class=\\"image-error\\"><span>📷 图片加载失败</span></div>"'>
                     </div>
-                    ${message.content.alt ? `<div class="image-caption">${message.content.alt}</div>` : ''}
                 </div>
             `;
         }
@@ -583,16 +589,18 @@
         }
 
         // 处理消息撤回
-        function handleMessageRevoked(messageId) {
-            const messageElements = document.querySelectorAll('.message-item');
-            messageElements.forEach(element => {
-                const messageBubble = element.querySelector('.message-bubble');
-                if (messageBubble && !messageBubble.classList.contains('revoked')) {
-                    // 这里可以通过消息ID来精确定位，简化处理
-                    messageBubble.classList.add('revoked');
-                    messageBubble.textContent = '此消息已被撤回';
-                }
-            });
+        function handleMessageRevoked(messageId, by, isSelf) {
+            const messageElement = document.getElementById('msg-' + messageId);
+            if (messageElement) {
+                messageElement.remove();
+            }
+
+            const name = by || '某人';
+            let tip = `${name} 撤回了一条消息`;
+            if (isSelf) {
+                tip += `，<span class="re-edit" data-id="${messageId}">重新编辑</span>`;
+            }
+            addSystemMessage(tip);
         }
 
         // 处理举手
@@ -619,6 +627,8 @@
                 quote: currentQuote
             }));
             input.value = '';
+            input.style.height = '20px';
+            adjustTextareaHeight();
             currentQuote = null;
             hideQuoteBar();
         }
@@ -808,6 +818,8 @@ emojiBtn.addEventListener('click', e => {
   // 切换显示/隐藏
   if (emojiPanel.style.display === 'block') {
     emojiPanel.style.display = 'none';
+    emojiPanel.style.left = '';
+    emojiPanel.style.top = '';
     return;
   }
   // 显示前隐式隐藏、设置定位
@@ -845,16 +857,21 @@ emojiPanel.addEventListener('click', function(e) {
                 messageInput.focus();
                 messageInput.setSelectionRange(cursorPos + emoji.length, cursorPos + emoji.length);
                 emojiPanel.style.display = 'none';
+                emojiPanel.style.left = '';
+                emojiPanel.style.top = '';
             }
         });
         document.addEventListener('click', function(e) {
             if (!emojiPanel.contains(e.target) && e.target !== emojiBtn) {
                 emojiPanel.style.display = 'none';
+                emojiPanel.style.left = '';
+                emojiPanel.style.top = '';
             }
         });
         // ========== 图片按钮功能 ==========
         const imageBtn = document.getElementById('imageBtn');
         const imageInput = document.getElementById('imageInput');
+        const imagePreviewPanel = document.getElementById('imagePreviewPanel');
         let selectedImageFile = null;
         imageBtn.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -865,10 +882,48 @@ emojiPanel.addEventListener('click', function(e) {
             const file = e.target.files[0];
             if (file && file.type.startsWith('image/')) {
                 selectedImageFile = file;
-                // 直接上传图片
-                sendImageFile(selectedImageFile);
+                showImagePreview(file);
             }
         });
+
+        function showImagePreview(data) {
+            let src = '';
+            let alt = '';
+            let imageId = '';
+            if (data instanceof File) {
+                src = URL.createObjectURL(data);
+                alt = data.name;
+                imagePreviewPanel.dataset.type = 'file';
+                imagePreviewPanel.dataset.alt = alt;
+            } else if (data && data.url) {
+                src = data.url;
+                alt = data.alt || '图片';
+                imageId = data.imageId || '';
+                imagePreviewPanel.dataset.type = 'url';
+                imagePreviewPanel.dataset.url = src;
+                imagePreviewPanel.dataset.imageId = imageId;
+                imagePreviewPanel.dataset.alt = alt;
+            } else {
+                return;
+            }
+            imagePreviewPanel.innerHTML = `<img src="${src}" alt="${alt}" style="max-width:150px;max-height:150px;border-radius:6px;display:block;margin-bottom:6px;">`+
+                `<div style="text-align:right;"><button id="sendImageConfirmBtn" style="margin-right:8px;">发送</button><button id="cancelImageBtn">取消</button></div>`;
+            imagePreviewPanel.style.display = 'block';
+            const rect = imageBtn.getBoundingClientRect();
+            const { scrollLeft, scrollTop } = document.documentElement;
+            imagePreviewPanel.style.left = (scrollLeft + rect.left) + 'px';
+            imagePreviewPanel.style.bottom = (window.innerHeight - rect.top + 10) + 'px';
+        }
+
+        function hideImagePreview() {
+            imagePreviewPanel.style.display = 'none';
+            imagePreviewPanel.innerHTML = '';
+            delete imagePreviewPanel.dataset.type;
+            delete imagePreviewPanel.dataset.url;
+            delete imagePreviewPanel.dataset.imageId;
+            delete imagePreviewPanel.dataset.alt;
+            selectedImageFile = null;
+        }
         async function sendImageFile(file) {
             try {
                 const formData = new FormData();
@@ -892,15 +947,12 @@ emojiPanel.addEventListener('click', function(e) {
                 }));
                 selectedImageFile = null;
                 imageInput.value = '';
+                hideImagePreview();
             } catch (err) {
                 alert('图片上传失败: ' + err.message);
             }
         }
-        document.addEventListener('click', function(e) {
-            if (!imagePreviewPanel.contains(e.target) && e.target !== imageBtn) {
-                imagePreviewPanel.style.display = 'none';
-            }
-        });
+
 
         // ========== 引用对话功能 ==========
         // 监听引用按钮点击
@@ -927,15 +979,37 @@ emojiPanel.addEventListener('click', function(e) {
                     sendRevoke(id);
                 }
             }
-            if (e.target.classList.contains('edit-btn')) {
-                const id = e.target.getAttribute('data-msgid');
-                const msg = messages.find(m => m.id === id);
-                if (msg) {
-                    const newText = prompt('修改消息内容', typeof msg.content === 'string' ? msg.content : '');
-                    if (newText !== null) {
-                        sendEdit(id, newText);
-                    }
+            if (e.target.classList.contains('re-edit')) {
+                const id = e.target.getAttribute('data-id');
+                const content = revokedCache[id];
+                if (content && typeof content === 'object') {
+                    showImagePreview(content);
+                } else {
+                    const input = document.getElementById('messageInput');
+                    input.value = content || '';
+                    input.focus();
                 }
+            }
+            if (e.target.id === 'sendImageConfirmBtn') {
+                if (imagePreviewPanel.dataset.type === 'file' && selectedImageFile) {
+                    sendImageFile(selectedImageFile);
+                } else if (imagePreviewPanel.dataset.type === 'url') {
+                    ws.send(JSON.stringify({
+                        type: 'image',
+                        content: {
+                            url: imagePreviewPanel.dataset.url,
+                            imageId: imagePreviewPanel.dataset.imageId,
+                            alt: imagePreviewPanel.dataset.alt || '图片'
+                        }
+                    }));
+                }
+                hideImagePreview();
+            }
+            if (e.target.id === 'cancelImageBtn') {
+                hideImagePreview();
+            }
+            if (imagePreviewPanel.style.display === 'block' && !imagePreviewPanel.contains(e.target) && e.target !== imageBtn) {
+                hideImagePreview();
             }
         });
         // 显示引用条
@@ -982,35 +1056,6 @@ emojiPanel.addEventListener('click', function(e) {
         function sendRevoke(id) {
             if (ws) {
                 ws.send(JSON.stringify({ type: 'revokeMessage', messageId: id }));
-            }
-        }
-
-        // 编辑消息
-        async function sendEdit(id, newText) {
-            try {
-                const res = await fetch('/api/messages/' + id, {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': 'Bearer ' + localStorage.getItem('token')
-                    },
-                    body: JSON.stringify({ content: newText })
-                });
-                await handleApiResponse(res);
-                if (res.ok) {
-                    const msg = messages.find(m => m.id === id);
-                    if (msg) {
-                        msg.content = newText;
-                        msg.edited = true;
-                    }
-                    const bubble = document.querySelector('#msg-' + id + ' .message-bubble');
-                    if (bubble) bubble.textContent = newText + ' (已编辑)';
-                } else {
-                    const err = await res.json();
-                    alert(err.error || '编辑失败');
-                }
-            } catch (err) {
-                alert('编辑失败: ' + err.message);
             }
         }
 


### PR DESCRIPTION
## Summary
- center own message bubbles with less whitespace
- tone down role labels
- add image preview panel and re-edit handling for revoked images
- hide emoji panel positions properly
- remove inline edit feature

## Testing
- `node node_modules/jest/bin/jest.js --runInBand` *(fails: TextChatController and integration text chat tests)*

------
https://chatgpt.com/codex/tasks/task_e_68623af1ad088327b7bbed96ebedc120