### PR TITLE
Add message sanitization

### DIFF
--- a/services/avatarService.js
+++ b/services/avatarService.js
@@ -43,7 +43,7 @@ class AvatarService {
    * @param {number} size - 头像尺寸
    * @returns {string} 头像URL
    */
-  generateRoleBasedAvatar(username, role, size = 40) {
+  generateRoleBasedAvatar(username = 'U', role = 'delegate', size = 40) {
     const roleColors = {
       'admin': '#ff4757',
       'host': '#2ed573',
@@ -55,7 +55,8 @@ class AvatarService {
     };
     
     const color = roleColors[role] || '#747d8c';
-    const initials = username.substring(0, 2).toUpperCase();
+    const safeName = (username || 'U').toString();
+    const initials = safeName.substring(0, 2).toUpperCase();
     
     // 生成SVG头像
     const svg = `

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -1,0 +1,22 @@
+"use strict";
+
+function sanitizeString(input) {
+  return String(input || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Sanitize the value only if it is a non-empty string. Otherwise return
+ * the value unchanged so objects like image payloads remain intact.
+ * @param {*} value
+ * @returns {*}
+ */
+function sanitizeIfString(value) {
+  return typeof value === "string" ? sanitizeString(value) : value;
+}
+
+module.exports = { sanitizeString, sanitizeIfString };


### PR DESCRIPTION
## Summary
- sanitize usernames and message text in textChatController instead of service
- provide shared sanitize utility
- skip sanitizing non-string values so image objects stay intact

## Testing
- `node node_modules/jest/bin/jest.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68623af1ad088327b7bbed96ebedc120